### PR TITLE
Add object tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install --save-dev simplytyped
 
 **[Objects](#objects)**
 
-[Keys](#keys) - [ObjectType](#objecttype) - [CombineObjects](#combineobjects) - [Intersect](#intersect) - [SharedKeys](#sharedkeys) - [DiffKeys](#diffkeys) - [AllKeys](#allkeys) - [Omit](#omit) - [Merge](#merge) - [Overwrite](#overwrite) - [DeepPartial](#deeppartial) - [DeepReadonly](#deepreadonly) - [Optional](#optional) - [GetKey](#getkey) - [AllRequired](#allrequired) - [Required](#required)
+[Keys](#keys) - [ObjectType](#objecttype) - [CombineObjects](#combineobjects) - [Intersect](#intersect) - [SharedKeys](#sharedkeys) - [DiffKeys](#diffkeys) - [AllKeys](#allkeys) - [Omit](#omit) - [Merge](#merge) - [Overwrite](#overwrite) - [DeepPartial](#deeppartial) - [DeepReadonly](#deepreadonly) - [Optional](#optional) - [GetKey](#getkey) - [AllRequired](#allrequired) - [Required](#required) - [TaggedObject](#taggedobject)
 
 **[Tuples](#tuples)**
 
@@ -278,6 +278,25 @@ Makes certain fields of an object "required"
 ```ts
 type x = { a?: string, b: number | undefined };
 type o = Required<x, 'a'>; // => { a: string, b: number | undefined }
+```
+
+### TaggedObject
+Creates an object with each entry being tagged by the key defining that entry.
+```ts
+const obj = {
+    a: { merp: 'hi' },
+    b: { merp: 'there' },
+    c: { merp: 'friend' },
+};
+
+const got = taggedObject(obj, 'name');
+/*
+got = {
+    a: { name: 'a', merp: 'hi' },
+    b: { name: 'b', merp: 'there' },
+    c: { name: 'c', merp: 'friend' },
+};
+*/
 ```
 
 ## Utils

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "simplytyped",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "yet another Typescript type library for advanced types",
     "main": "dist/src/index",
     "types": "dist/src/index.d.ts",

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -2,6 +2,7 @@ import { Diff, UnionContains } from './strings';
 import { IsObject } from './predicates';
 import { If } from './conditionals';
 import { NotNullable } from './utils';
+import { objectKeys } from './functions';
 
 export type PlainObject = Record<string, any>;
 
@@ -48,3 +49,19 @@ export interface ConstructorFor<T extends object> {
 }
 
 export type InstanceOf<T extends ConstructorFor<any>> = T['prototype'];
+
+export type TaggedObject<T extends Record<string, object>, Key extends string> = {
+    [K in keyof T]: CombineObjects<T[K], Record<Key, K>>;
+};
+
+export const taggedObject = <T extends Record<string, object>, K extends string>(obj: T, key: K): TaggedObject<T, K> => {
+    const keys = objectKeys(obj);
+    return keys.reduce((collection: any, k) => {
+        const inner: any = obj[k];
+        collection[k] = {
+            [key]: k,
+            ...inner,
+        };
+        return collection;
+    }, {} as TaggedObject<T, K>);
+};

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -51,7 +51,7 @@ export interface ConstructorFor<T extends object> {
 export type InstanceOf<T extends ConstructorFor<any>> = T['prototype'];
 
 export type TaggedObject<T extends Record<string, object>, Key extends string> = {
-    [K in keyof T]: CombineObjects<T[K], Record<Key, K>>;
+    [K in keyof T]: T[K] & Record<Key, K>;
 };
 
 export const taggedObject = <T extends Record<string, object>, K extends string>(obj: T, key: K): TaggedObject<T, K> => {

--- a/test/objects.ts
+++ b/test/objects.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { AllKeys, CombineObjects, DeepPartial, DeepReadonly, DiffKeys, Intersect, Keys, Merge, ObjectType, Omit, Optional, Overwrite, SharedKeys, UnionizeProperties, ConstructorFor, InstanceOf, Required, AllRequired } from '../src/index';
+import { AllKeys, CombineObjects, DeepPartial, DeepReadonly, DiffKeys, Intersect, Keys, Merge, ObjectType, Omit, Optional, Overwrite, SharedKeys, UnionizeProperties, ConstructorFor, InstanceOf, Required, AllRequired, taggedObject } from '../src/index';
 
 function assert<T, U extends T>(t: { pass: any }) { t.pass(); }
 
@@ -191,4 +191,23 @@ test('Can make certain fields of options object required', t => {
     assert<got1, expected1>(t);
     assert<got2, expected2>(t);
     assert<got3, expected3>(t);
+});
+
+test('Can generate a tagged object', t => {
+    const obj = {
+        a: { merp: 'hi' },
+        b: { merp: 'there' },
+        c: { merp: 'friend' },
+    };
+
+    const expected = {
+        a: { name: 'a' as 'a', merp: 'hi' },
+        b: { name: 'b' as 'b', merp: 'there' },
+        c: { name: 'c' as 'c', merp: 'friend' },
+    };
+
+    const got = taggedObject(obj, 'name');
+
+    t.deepEqual(got, expected);
+    assert<typeof got, typeof expected>(t);
 });


### PR DESCRIPTION
This is really useful when creating enum-like objects that you want to be able to do discriminated unions with in the future. Helps save several redundant lines of code when defining the object.