### PR TITLE
tighten package json versions now that we are using greenkeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     },
     "devDependencies": {
         "@commitlint/config-conventional": "^6.1.3",
-        "@types/node": "^9.6.2",
-        "ava": "^0.25.0",
+        "@types/node": "~9.6.2",
+        "ava": "~0.25.0",
         "commitlint": "^6.1.3",
         "husky": "^0.15.0-rc.13",
         "ts-node": "^5.0.1",


### PR DESCRIPTION
With greenkeeper we can keep a tighter reign on the package.json versions. The bot will automatically create PRs whenever one of the dependencies change outside of our specified range (so whenever a minor version changes) as long as the new version passes CI.