### PR TITLE
feat(tuple): add IntersectTuple type

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install --save-dev simplytyped
 
 **[Tuples](#tuples)**
 
-[Tuple](#tuple) - [UnionizeTuple](#unionizetuple) - [Length](#length)
+[Tuple](#tuple) - [UnionizeTuple](#unionizetuple) - [IntersectTuple](#intersecttuple) - [Length](#length)
 
 **[Strings](#strings)**
 
@@ -343,6 +343,13 @@ doStuff(['hi', 'there']); // => doStuff(x: ['hi', 'there']): void
 Returns elements within a tuple as a union.
 ```ts
 type x = UnionizeTuple<[number, string]> // => number | string
+```
+
+### IntersectTuple
+Returns elements of a tuple intersected with each other.
+**Note: only works for tuples up to length 10**
+```ts
+type x = IntersectTuple<[{a: 'hi'}, {b: 'there'}]>; // => {a: 'hi'} & {b: 'there'}
 ```
 
 ### Length

--- a/src/types/tuples.ts
+++ b/src/types/tuples.ts
@@ -2,3 +2,15 @@ export interface Vector<T> { readonly [x: number]: T; readonly length: number; }
 export type Length<T extends Vector<any>> = T['length'];
 
 export type UnionizeTuple<T extends Vector<any>> = T[number];
+export type IntersectTuple<T extends Vector<any>> =
+    Length<T> extends 1 ? T[0] :
+    Length<T> extends 2 ? T[0] & T[1] :
+    Length<T> extends 3 ? T[0] & T[1] & T[2] :
+    Length<T> extends 4 ? T[0] & T[1] & T[2] & T[3] :
+    Length<T> extends 5 ? T[0] & T[1] & T[2] & T[3] & T[4] :
+    Length<T> extends 6 ? T[0] & T[1] & T[2] & T[3] & T[4] & T[5] :
+    Length<T> extends 7 ? T[0] & T[1] & T[2] & T[3] & T[4] & T[5] & T[6] :
+    Length<T> extends 8 ? T[0] & T[1] & T[2] & T[3] & T[4] & T[5] & T[6] & T[7] :
+    Length<T> extends 9 ? T[0] & T[1] & T[2] & T[3] & T[4] & T[5] & T[6] & T[7] & T[8] :
+    Length<T> extends 10 ? T[0] & T[1] & T[2] & T[3] & T[4] & T[5] & T[6] & T[7] & T[8] & T[9] :
+        any;

--- a/test/tuples.ts
+++ b/test/tuples.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { Length, Vector, UnionizeTuple } from '../src/index';
+import { Length, Vector, UnionizeTuple, IntersectTuple } from '../src/index';
 
 function assert<T, U extends T>(t: { pass: any }) { t.pass(); }
 
@@ -36,4 +36,13 @@ test('Can get the length of a tuple', t => {
 
     assert<gotX, 2>(t);
     assert<gotT, 4>(t);
+});
+
+test('Can get the intersection of tuple values', t => {
+    type t = [{a: 'hi'}, {b: 'there'}, {c: 'friend'}];
+
+    type got = IntersectTuple<t>;
+    type expected = {a: 'hi'} & {b: 'there'} & {c: 'friend'};
+
+    assert<got, expected>(t);
 });


### PR DESCRIPTION
It is unfortunate to have to use nested `if`s for this. I cannot think of another way to solve this problem. Need this for schema validation with the `anyOf` validator:

```javascript
{
  anyOf: [
    { type: 'string' },
    { type: 'number' },
  ],
}
```