### PR TITLE
feat: fix typescript 2.9 errors

### DIFF
--- a/src/impl/objects.ts
+++ b/src/impl/objects.ts
@@ -1,6 +1,6 @@
-import { DeepReadonly, Keys, TaggedObject } from '../types/objects';
+import { DeepReadonly, Keys, TaggedObject, StringKeys } from '../types/objects';
 
-export function isKeyOf<T extends object>(obj: T, k: string): k is keyof T {
+export function isKeyOf<T extends object>(obj: T, k: string): k is StringKeys<T> {
     return Object.keys(obj).includes(k);
 }
 

--- a/src/types/numbers.ts
+++ b/src/types/numbers.ts
@@ -1,13 +1,11 @@
 import { True, False } from './conditionals';
-import { StringEqual } from './strings';
-import { Vector } from './tuples';
 
-export type IsZero<T extends number> = (Vector<False> & [True, False])[T];
-export type IsOne<T extends number> = (Vector<False> & [False, True, False])[T];
+export type IsZero<T extends number> = T extends 0 ? True : False;
+export type IsOne<T extends number> = T extends 1 ? True : False;
 export type NumberToString<N extends number> = Numbers[N];
 export type Numbers = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63'];
 export type Next<T extends number> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64][T];
 export type Prev<T extends number> = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62][T];
-export type Add<A extends number, B extends number> = { 1: A, 0: Add<Next<A>, Prev<B>> }[IsZero<B>];
-export type Sub<A extends number, B extends number> = { 1: A, 0: Sub<Prev<A>, Prev<B>> }[IsZero<B>];
-export type NumberEqual<A extends number, B extends number> = StringEqual<NumberToString<A>, NumberToString<B>>;
+export type Add<A extends number, B extends number> = { '1': A, '0': Add<Next<A>, Prev<B>> }[IsZero<B>];
+export type Sub<A extends number, B extends number> = { '1': A, '0': Sub<Prev<A>, Prev<B>> }[IsZero<B>];
+export type NumberEqual<A extends number, B extends number> = A extends B ? B extends A ? True : False : False;

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -16,6 +16,7 @@ export type GetKey<T, K extends string> = K extends Keys<T> ? T[K] : never;
 // ----
 // Keys
 // ----
+export type StringKeys<T> = Exclude<Keys<T>, number | symbol>;
 export type Keys<T> = keyof T;
 export type PureKeys<T> = Record<Keys<T>, Keys<T>>[Keys<T>];
 export type SharedKeys<T, U> = Keys<T> & Keys<U>;

--- a/src/types/predicates.ts
+++ b/src/types/predicates.ts
@@ -1,6 +1,5 @@
-import { False, True, ReallyTrue, And, Or, Not } from './conditionals';
-import { Diff, UnionContains } from './strings';
-import { Keys, HasKey } from './objects';
+import { False, True, And, Or, Not } from './conditionals';
+import { Keys } from './objects';
 import { AnyFunc } from './functions';
 
 export type KnownProblemPrototypeKeys = 'toString' | 'toLocaleString' | 'hasOwnProperty' | 'isPrototypeOf' | 'propertyIsEnumerable' | 'constructor' | 'valueOf';
@@ -11,7 +10,7 @@ export type StringPrototypeKeys = Keys<string>;
 export type ObjectPrototypeKeys = Keys<Object>; // tslint:disable-line
 export type FunctionPrototypeKeys = Keys<Function>; // tslint:disable-line
 
-export type IsNever<S extends string> = UnionContains<UnionContains<S, S>, False>;
+export type IsNever<S extends string> = Not<(Record<S, True> & Record<string, False>)[S]>;
 export type IsType<T, X> = X extends T ? True : False;
 export type IsArray<T> = T extends any[] ? True : False;
 export type IsNumber<T> = T extends number ? True : False;

--- a/src/types/strings.ts
+++ b/src/types/strings.ts
@@ -1,7 +1,9 @@
 import { True, False, And } from './conditionals';
 import { IsNever } from './predicates';
 
-export type Diff<T extends string, U extends string> = Exclude<T, U>;
+// TODO: this is here only for backwards compatibility
+export type Diff<T, U> = Exclude<T, U>;
+
 export type DropString<T extends string, U extends T> = Diff<T, U>;
 
 export type StringEqual<T extends string, U extends string> =
@@ -10,4 +12,4 @@ export type StringEqual<T extends string, U extends string> =
         IsNever<Diff<U, T>>
     >;
 
-export type UnionContains<T extends string, U extends string> = (Record<T, True> & Record<string, False>)[U];
+export type UnionContains<T, U> = U extends T ? True : False;


### PR DESCRIPTION
Typescript 2.9 makes `keyof` return `string | number | symbol` instead
of simply `string`. This is a breaking change with TS, meaning it broke
several methods that relied on keyof returning a string within ST.