### PR TITLE
perf: improve performance of Overwrite and Merge

### DIFF
--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -30,8 +30,10 @@ export type HasKey<T, U extends string | number | symbol> = U extends Keys<T> ? 
 export type UnionizeProperties<T extends object> = T[Keys<T>];
 export type Omit<T extends object, K extends Keys<T>> = Pick<T, Diff<Keys<T>, K>>;
 export type Intersect<T extends object, U extends Partial<T>> = Omit<U, DiffKeys<U, T>>;
-export type Merge<T extends object, U extends object> = CombineObjects<Omit<T, SharedKeys<T, U>>, U>;
-export type Overwrite<T extends object, U extends object> = Merge<T, Intersect<T, U>>;
+export type Overwrite<T extends object, U extends object> = {
+    [k in keyof T]: k extends keyof U ? U[k] : T[k];
+};
+export type Merge<T extends object, U extends object> = CombineObjects<Overwrite<T, U>, U>;
 export type TaggedObject<T extends Record<string, object>, Key extends string> = {
     [K in Keys<T>]: T[K] & Record<Key, K>;
 };


### PR DESCRIPTION
Previously Overwrite was written in terms of Merge, and Merge was not
particularly performant (many iterations over object keys). With TS 2.8,
Overwrite became much easier to write with a single iteration over the
left object's keys, and no iterations over the right object's keys. This
should lead to dramatic performance gains for Overwrite.

To take advantage of these performance benefits, Merge is now written in
terms of an Overwrite operation; instead of the other way around. This
should result in a small improvement in Merge's performance.