### PR TITLE
chore: use non-RC version of husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
         "test:all": "npm run test:ts2.8.1 && npm run test:tsnext",
         "tsc": "tsc",
         "prepub": "rm -rf dist && npm -s run tsc && ts-node scripts/preparePublish.ts",
-        "release": "npm run -s prepub && cd dist/src && npx semantic-release"
+        "release": "npm run -s prepub && cd dist/src && npx semantic-release",
+        "commitmsg": "commitlint -e $GIT_PARAMS",
+        "prepush": "npm run -s lint && npm run -s test"
     },
     "repository": {
         "type": "git",
@@ -40,7 +42,7 @@
         "@types/node": "~10.1.0",
         "ava": "~0.25.0",
         "commitlint": "^6.1.3",
-        "husky": "^0.15.0-rc.13",
+        "husky": "^0.14.3",
         "ts-node": "^6.0.0",
         "tslint": "^5.8.0"
     },
@@ -53,9 +55,5 @@
         "extends": [
             "@commitlint/config-conventional"
         ]
-    },
-    "husky": {
-        "commitmsg": "commitlint -e $GIT_PARAMS",
-        "prepush": "npm run -s lint && npm run -s test"
     }
 }


### PR DESCRIPTION
The RC versions seem a bit flaky and unstable. Going back from beta releases to the latest stable. Will re-evaluate if v1 ever manages to drop (currently on v1.0.0-rc7)