### PR TITLE
make Merge work with record-like interfaces 

### DIFF
--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -33,7 +33,7 @@ export type Intersect<T extends object, U extends Partial<T>> = Omit<U, DiffKeys
 export type Overwrite<T extends object, U extends object> = {
     [k in keyof T]: k extends keyof U ? U[k] : T[k];
 };
-export type Merge<T extends object, U extends object> = CombineObjects<Overwrite<T, U>, U>;
+export type Merge<T extends object, U extends object> = Overwrite<T, U> & U;
 export type TaggedObject<T extends Record<string, object>, Key extends string> = {
     [K in Keys<T>]: T[K] & Record<Key, K>;
 };

--- a/test/objects.ts
+++ b/test/objects.ts
@@ -94,6 +94,20 @@ test('Can merge two objects, resolving matching keys by rightmost object', t => 
     assert<got, expected>(t);
 });
 
+test('Can merge an object containing all strings as keys', t => {
+    type a = {
+        y: string;
+        [s: string]: string;
+    };
+    type b = { x: number, y: number };
+
+    type got = Merge<a, b>;
+    type expected = { x: number, y: number } & Record<string, string>;
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
+});
+
 test('Can get a deep partial object', t => {
     type a = {
         b: {


### PR DESCRIPTION
By iterating over the keys of the merged object, we fail to work with
interfaces that allow any string key. For instance:
```typescript
interface Thing {
    x: 'hi';
    [s: string]: any;
}
```