### PR TITLE
fix: handle arrays in deeply nested objects

### DIFF
--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -1,5 +1,5 @@
 import { Diff } from './strings';
-import { IsObject } from './predicates';
+import { IsObject, IsArray } from './predicates';
 import { If, False, True } from './conditionals';
 import { Nullable } from './utils';
 
@@ -41,12 +41,11 @@ export type TaggedObject<T extends Record<string, object>, Key extends string> =
 // ---------
 // Accessors
 // ---------
-export type DeepPartial<T extends PlainObject> = Partial<{
+export type DeepPartial<T> = Partial<{
     [k in Keys<T>]:
-        If<IsObject<T[k]>,
-            DeepPartial<T[k]>,
-            T[k]
-        >
+        T[k] extends any[] ? Array<DeepPartial<T[k][number]>> :
+        T[k] extends object ? DeepPartial<T[k]> :
+            T[k];
 }>;
 export type AllRequired<T extends object> = {
     [K in Keys<T>]-?: NonNullable<T[K]>
@@ -59,12 +58,11 @@ export type Optional<T extends object, K extends Keys<T>> = CombineObjects<
     {[k in K]?: Nullable<T[k]> },
     Omit<T, K>
 >;
-export type DeepReadonly<T extends PlainObject> = Readonly<{
+export type DeepReadonly<T> = Readonly<{
     [k in Keys<T>]:
-        If<IsObject<T[k]>,
-            DeepReadonly<T[k]>,
-            T[k]
-        >
+        T[k] extends any[] ? Array<DeepReadonly<T[k][number]>> :
+        T[k] extends object ? DeepReadonly<T[k]> :
+            T[k];
 }>;
 export type KeysByType<O extends object, T> = {
     [k in keyof O]: O[k] extends T ? k : never;

--- a/test/objects.ts
+++ b/test/objects.ts
@@ -127,6 +127,23 @@ test('Can get a deep partial object', t => {
     assert<got, expected>(t);
 });
 
+test('Can get a deep partial object with arrays', t => {
+    type a = {
+        b: [{
+            c: number,
+        }],
+    };
+
+    type got = DeepPartial<a>;
+    type expected = {
+        b?: [{
+            c?: number,
+        }],
+    };
+
+    assert<got, expected>(t);
+});
+
 test('Can get an object with only shared properties', t => {
     type a = { x: number, y: string };
     type b = { y: string, z: string };
@@ -157,6 +174,15 @@ test('Can make nested object readonly', t => {
     type x = { x: { a: 1, b: 'hi' }, y: 'hey' };
 
     type expected = { readonly x: Readonly<{ a: 1, b: 'hi' }>, readonly y: 'hey' };
+    type got = DeepReadonly<x>;
+
+    assert<got, expected>(t);
+});
+
+test('Can make nested object with arrays readonly', t => {
+    type x = { x: [{ a: 1, b: 'hi' }], y: 'hey' };
+
+    type expected = { readonly x: Array<Readonly<{ a: 1, b: 'hi' }>>, readonly y: 'hey' };
     type got = DeepReadonly<x>;
 
     assert<got, expected>(t);


### PR DESCRIPTION
Currently we do not handle arrays that are nested in objects when doing
a "deep" operation. For example `DeepPartial` is currently giving:
```typescript
type x = DeepPartial<{
    x: [{
        y: number
    }]
}>;
/*
x = {
    x?: Partial<Array<{ y: number }>>
}
*/
```