### PR TITLE
fix: require any version of TS greater than 2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ],
     "homepage": "https://github.com/andnp/SimplyTyped#readme",
     "peerDependencies": {
-        "typescript": "^2.8.1"
+        "typescript": ">2.8.1"
     },
     "devDependencies": {
         "@commitlint/config-conventional": "^6.1.3",


### PR DESCRIPTION
Previously, npm would throw an error for minor versions larger than 8.
Since simplytyped is tested against the latest beta version of TS daily,
we can feel confident that it will work with any version over 2.8.

Because we use the mapped conditional syntax introduced in 2.8, we must
specify it as the minimum. If we ever start using any of the 2.9 syntax
(which we probably won't since none of its features seem to affect this
project), then we could bump the peer dependency at that point.