### PR TITLE
fix: use ReadonlyArray inside DeepReadonly

### DIFF
--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -195,7 +195,7 @@ export type Optional<T extends object, K extends Keys<T>> = CombineObjects<
  */
 export type DeepReadonly<T> = Readonly<{
     [k in Keys<T>]:
-        T[k] extends any[] ? Array<DeepReadonly<T[k][number]>> :
+        T[k] extends any[] ? ReadonlyArray<DeepReadonly<T[k][number]>> :
         T[k] extends object ? DeepReadonly<T[k]> :
             T[k];
 }>;

--- a/test/objects/DeepReadonly.test.ts
+++ b/test/objects/DeepReadonly.test.ts
@@ -16,7 +16,7 @@ test('Can make nested object readonly', t => {
 test('Can make nested object with arrays readonly', t => {
     type x = { x: [{ a: 1, b: 'hi' }], y: 'hey' };
 
-    type expected = { readonly x: Array<Readonly<{ a: 1, b: 'hi' }>>, readonly y: 'hey' };
+    type expected = { readonly x: ReadonlyArray<Readonly<{ a: 1, b: 'hi' }>>, readonly y: 'hey' };
     type got = DeepReadonly<x>;
 
     assert<got, expected>(t);


### PR DESCRIPTION
Using ReadonlyArray inside DeepReadonly so that the arrays cannot be mutated.  Currently this code type checks:

```
declare const obj: DeepReadonly<{numbers: number[]}>;
obj.numbers[0] = 5;
obj.numbers.push(6);
```

But both the second and third lines are type errors when using `ReadonlyArray`.