### PR TITLE
Args as tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install --save-dev simplytyped
 
 **[Functions](#functions)**
 
-[AnyFunc](#anyfunc) - [ConstructorFunction](#constructorfunction) - [OverwriteReturn](#overwritereturn) - [Predicate](#predicate)
+[AnyFunc](#anyfunc) - [ArgsAsTuple](#argsastuple) - [ConstructorFunction](#constructorfunction) - [OverwriteReturn](#overwritereturn) - [Predicate](#predicate)
 
 **[Strings](#strings)**
 
@@ -506,6 +506,28 @@ test('Can define the type of a function that takes any arguments', t => {
 
     assert<got, expected>(t);
     assert<got2, expected2>(t);
+});
+
+```
+
+### ArgsAsTuple
+Returns a tuple type of a functions arguments up to 7.
+```ts
+test("Can get a tuple of function's argument types", t => {
+    type F0 = () => any;
+    type F1 = (x: number) => any;
+    type F2 = (x: number, y: string) => any;
+    type F3 = (x: number, y: string, z: boolean) => any;
+
+    type E0 = void[];
+    type E1 = [number];
+    type E2 = [number, string];
+    type E3 = [number, string, boolean];
+
+    assert<ArgsAsTuple<F0>, E0>(t);
+    assert<ArgsAsTuple<F1>, E1>(t);
+    assert<ArgsAsTuple<F2>, E2>(t);
+    assert<ArgsAsTuple<F3>, E3>(t);
 });
 
 ```

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -31,3 +31,19 @@ export type OverwriteReturn<F extends AnyFunc, R> =
     F extends (x1: infer X1, x2: infer X2, x3: infer X3, x4: infer X4, x5: infer X5, x6: infer X6) => any ? (x1: X1, x2: X2, x3: X3, x4: X4, x5: X5, x6: X6) => R :
     F extends (x1: infer X1, x2: infer X2, x3: infer X3, x4: infer X4, x5: infer X5, x6: infer X6, x7: infer X7) => any ? (x1: X1, x2: X2, x3: X3, x4: X4, x5: X5, x6: X6, x7: X7) => R :
         AnyFunc<R>;
+
+/**
+ * Returns a tuple type of a functions arguments up to 7.
+ * @param F a function with up to 7 arguments
+ * @returns a tuple containing `F`'s argument types
+ */
+export type ArgsAsTuple<F extends AnyFunc> =
+    F extends () => any ? void[] :
+    F extends (x1: infer X1) => any ? [X1] :
+    F extends (x1: infer X1, x2: infer X2) => any ? [X1, X2] :
+    F extends (x1: infer X1, x2: infer X2, x3: infer X3) => any ? [X1, X2, X3] :
+    F extends (x1: infer X1, x2: infer X2, x3: infer X3, x4: infer X4) => any ? [X1, X2, X3, X4] :
+    F extends (x1: infer X1, x2: infer X2, x3: infer X3, x4: infer X4, x5: infer X5) => any ? [X1, X2, X3, X4, X5] :
+    F extends (x1: infer X1, x2: infer X2, x3: infer X3, x4: infer X4, x5: infer X5, x6: infer X6) => any ? [X1, X2, X3, X4, X5, X6] :
+    F extends (x1: infer X1, x2: infer X2, x3: infer X3, x4: infer X4, x5: infer X5, x6: infer X6, x7: infer X7) => any ? [X1, X2, X3, X4, X5, X6, X7] :
+        any[];

--- a/test/functions/ArgsAsTuple.test.ts
+++ b/test/functions/ArgsAsTuple.test.ts
@@ -1,0 +1,21 @@
+import test from 'ava';
+import { assert } from '../helpers/assert';
+
+import { ArgsAsTuple } from '../../src';
+
+test("Can get a tuple of function's argument types", t => {
+    type F0 = () => any;
+    type F1 = (x: number) => any;
+    type F2 = (x: number, y: string) => any;
+    type F3 = (x: number, y: string, z: boolean) => any;
+
+    type E0 = void[];
+    type E1 = [number];
+    type E2 = [number, string];
+    type E3 = [number, string, boolean];
+
+    assert<ArgsAsTuple<F0>, E0>(t);
+    assert<ArgsAsTuple<F1>, E1>(t);
+    assert<ArgsAsTuple<F2>, E2>(t);
+    assert<ArgsAsTuple<F3>, E3>(t);
+});


### PR DESCRIPTION
This type helper can take a function with up to 7 args and return a
tuple of its arguments. This can be useful in cases where a TS class
encapsulates a function, but cannot provide overloaded methods to match
given function signature.

Example:
```typescript
class Doer<F extends AnyFunc> {
    constructor(private f: F) {}

    doThing(args: ArgsAsTuple<F>) { return this.f(); }
}
```