### PR TITLE
fix: bail out of deep types with function values

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,29 @@ test('Can get a deep partial object with arrays', t => {
     assert<expected, got>(t);
 });
 
+test('Can get a deep partial object with functions', t => {
+    type x = {
+        a: () => 22,
+        b: string,
+        c: {
+            d: number,
+        },
+    };
+
+    type expected = {
+        a?: () => 22,
+        b?: string,
+        c?: {
+            d?: number,
+        },
+    };
+
+    type got = DeepPartial<x>;
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
+});
+
 ```
 
 ### DeepReadonly
@@ -166,6 +189,28 @@ test('Can make nested object with arrays readonly', t => {
     type x = { x: [{ a: 1, b: 'hi' }], y: 'hey' };
 
     type expected = { readonly x: ReadonlyArray<Readonly<{ a: 1, b: 'hi' }>>, readonly y: 'hey' };
+    type got = DeepReadonly<x>;
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
+});
+
+test('Can make an object with functions readonly', t => {
+    type x = {
+        a: () => 22,
+        b: string,
+        c: {
+            d: boolean,
+        },
+    };
+
+    type expected = {
+        readonly a: () => 22,
+        readonly b: string,
+        readonly c: {
+            readonly d: boolean,
+        },
+    };
     type got = DeepReadonly<x>;
 
     assert<got, expected>(t);

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -1,5 +1,6 @@
 import { Diff } from './strings';
 import { False, True } from './conditionals';
+import { AnyFunc } from 'types/functions';
 
 // -------
 // Helpers
@@ -157,6 +158,7 @@ export type TaggedObject<T extends Record<keyof any, object>, Key extends keyof 
 export type DeepPartial<T> = Partial<{
     [k in Keys<T>]:
         T[k] extends any[] ? Array<DeepPartial<T[k][number]>> :
+        T[k] extends AnyFunc ? T[k] :
         T[k] extends object ? DeepPartial<T[k]> :
             T[k];
 }>;
@@ -196,6 +198,7 @@ export type Optional<T extends object, K extends Keys<T>> = CombineObjects<
 export type DeepReadonly<T> = Readonly<{
     [k in Keys<T>]:
         T[k] extends any[] ? ReadonlyArray<DeepReadonly<T[k][number]>> :
+        T[k] extends AnyFunc ? T[k] :
         T[k] extends object ? DeepReadonly<T[k]> :
             T[k];
 }>;

--- a/test/objects/DeepPartial.test.ts
+++ b/test/objects/DeepPartial.test.ts
@@ -40,3 +40,26 @@ test('Can get a deep partial object with arrays', t => {
     assert<got, expected>(t);
     assert<expected, got>(t);
 });
+
+test('Can get a deep partial object with functions', t => {
+    type x = {
+        a: () => 22,
+        b: string,
+        c: {
+            d: number,
+        },
+    };
+
+    type expected = {
+        a?: () => 22,
+        b?: string,
+        c?: {
+            d?: number,
+        },
+    };
+
+    type got = DeepPartial<x>;
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
+});

--- a/test/objects/DeepReadonly.test.ts
+++ b/test/objects/DeepReadonly.test.ts
@@ -22,3 +22,25 @@ test('Can make nested object with arrays readonly', t => {
     assert<got, expected>(t);
     assert<expected, got>(t);
 });
+
+test('Can make an object with functions readonly', t => {
+    type x = {
+        a: () => 22,
+        b: string,
+        c: {
+            d: boolean,
+        },
+    };
+
+    type expected = {
+        readonly a: () => 22,
+        readonly b: string,
+        readonly c: {
+            readonly d: boolean,
+        },
+    };
+    type got = DeepReadonly<x>;
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
+});


### PR DESCRIPTION
When recurring over deep object types, we should make sure that we are
not modifying any type that extends a function.