### PR TITLE
Preempt future typescript breaking change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save-dev simplytyped
 
 **[Objects](#objects)**
 
-[AllKeys](#allkeys) - [AllRequired](#allrequired) - [CombineObjects](#combineobjects) - [DeepPartial](#deeppartial) - [DeepReadonly](#deepreadonly) - [DiffKeys](#diffkeys) - [GetKey](#getkey) - [HasKey](#haskey) - [Intersect](#intersect) - [Keys](#keys) - [KeysByType](#keysbytype) - [Merge](#merge) - [ObjectType](#objecttype) - [Omit](#omit) - [Optional](#optional) - [Overwrite](#overwrite) - [PlainObject](#plainobject) - [PureKeys](#purekeys) - [Required](#required) - [SharedKeys](#sharedkeys) - [StringKeys](#stringkeys) - [TaggedObject](#taggedobject) - [UnionizeProperties](#unionizeproperties)
+[AllKeys](#allkeys) - [AllRequired](#allrequired) - [CombineObjects](#combineobjects) - [DeepPartial](#deeppartial) - [DeepReadonly](#deepreadonly) - [DiffKeys](#diffkeys) - [GetKey](#getkey) - [HasKey](#haskey) - [Intersect](#intersect) - [Keys](#keys) - [KeysByType](#keysbytype) - [Merge](#merge) - [ObjectKeys](#objectkeys) - [ObjectType](#objecttype) - [Omit](#omit) - [Optional](#optional) - [Overwrite](#overwrite) - [PlainObject](#plainobject) - [PureKeys](#purekeys) - [Required](#required) - [SharedKeys](#sharedkeys) - [StringKeys](#stringkeys) - [TaggedObject](#taggedobject) - [UnionizeProperties](#unionizeproperties)
 
 **[Utils](#utils)**
 
@@ -345,6 +345,15 @@ test('Can merge an object containing all strings as keys', t => {
 });
 
 ```
+
+### ObjectKeys
+Objects can be indexed by multiple types: `string`, `number`, `symbol`.
+For safe compatibility with typescript version, this type will always
+have the correct set of object key types for the current version of TS.
+
+This is useful for functions that must take a key, instead of `K extends string`,
+use `K extends ObjectKeys`.
+
 
 ### ObjectType
 Takes any type and makes it an object type.

--- a/scripts/generateDocumentation.ts
+++ b/scripts/generateDocumentation.ts
@@ -149,8 +149,12 @@ console.log(markdown);
 
 
 /** True if this is visible outside this file, false otherwise */
-function isNodeExported(node: tsc.Node): boolean {
-    return (tsc.getCombinedModifierFlags(node) & tsc.ModifierFlags.Export) !== 0 || (!!node.parent && node.parent.kind === tsc.SyntaxKind.SourceFile); // tslint:disable-line no-bitwise
+function isNodeExported(node: tsc.Node | tsc.Declaration): boolean {
+    const declaration: tsc.Declaration = {
+        _declarationBrand: 'branded',
+        ...node,
+    };
+    return (tsc.getCombinedModifierFlags(declaration) & tsc.ModifierFlags.Export) !== 0 || (!!declaration.parent && declaration.parent.kind === tsc.SyntaxKind.SourceFile); // tslint:disable-line no-bitwise
 }
 
 // TODO: make this less atrocious

--- a/src/impl/objects.ts
+++ b/src/impl/objects.ts
@@ -1,4 +1,4 @@
-import { DeepReadonly, Keys, TaggedObject } from '../types/objects';
+import { DeepReadonly, Keys, TaggedObject, ObjectKeys } from '../types/objects';
 
 /**
  * Type guard for any key, `k`.
@@ -34,7 +34,7 @@ export function Readonly<T extends object>(obj: T): DeepReadonly<T> { return obj
  * @param key the name of the "tag" parameter
  * @returns `obj` with the inner objects tagged with parameter `key` and the key pointing to that inner object
  */
-export function taggedObject<T extends Record<string, object>, K extends string>(obj: T, key: K): TaggedObject<T, K> {
+export function taggedObject<T extends Record<ObjectKeys, object>, K extends string>(obj: T, key: K): TaggedObject<T, K> {
     const keys = objectKeys(obj);
     return keys.reduce((collection: any, k) => {
         const inner: any = obj[k];

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -41,6 +41,15 @@ export type GetKey<T, K extends keyof any> = K extends Keys<T> ? T[K] : never;
 // Keys
 // ----
 /**
+ * Objects can be indexed by multiple types: `string`, `number`, `symbol`.
+ * For safe compatibility with typescript version, this type will always
+ * have the correct set of object key types for the current version of TS.
+ *
+ * This is useful for functions that must take a key, instead of `K extends string`,
+ * use `K extends ObjectKeys`.
+ */
+export type ObjectKeys = keyof any;
+/**
  * Typescript 2.9 introduced `number | symbol` as possible results from `keyof any`.
  * For backwards compatibility with objects containing only `string` keys, this will
  * exclude any `number | symbol` keys from `keyof`.


### PR DESCRIPTION
TL;DR `taggedObject` had a wrong signature. It should allow it's key to be any indexable type, not just `string`. I also created a helper here, because many of my recent projects have been using `keyof all` (which returns `string | number | symbol` with current TS versions, and just `string` for older TS versions) to get a more stable type for an index.