### PR TITLE
feat: remove IsAny case from Predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,15 +660,6 @@ test('Can build a predicate function with single known argument type', t => {
     assert<PredFunc, expected>(t);
 });
 
-test('Can build a predicate function with unknown argument types', t => {
-    type PredFunc = Predicate;
-    type works = (arg1: string, arg2: number) => boolean;
-    type expected = (...args: any[]) => boolean;
-
-    assert<PredFunc, works>(t);
-    assert<PredFunc, expected>(t);
-});
-
 ```
 
 ## Strings

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -8,7 +8,7 @@ export type ConstructorFunction<T extends object> = new (...args: any[]) => T;
 /**
  * This is a function that takes some args and returns a boolean
  */
-export type Predicate<A = any> = If<IsAny<A>, (...args: any[]) => boolean, (arg: A) => boolean>;
+export type Predicate<A = any> = (arg: A) => boolean;
 /**
  * Concisely and cleanly define an arbitrary function.
  * Useful when designing many api's that don't care what function they take in, they just need to know what it returns.

--- a/test/functions/Predicate.test.ts
+++ b/test/functions/Predicate.test.ts
@@ -9,12 +9,3 @@ test('Can build a predicate function with single known argument type', t => {
 
     assert<PredFunc, expected>(t);
 });
-
-test('Can build a predicate function with unknown argument types', t => {
-    type PredFunc = Predicate;
-    type works = (arg1: string, arg2: number) => boolean;
-    type expected = (...args: any[]) => boolean;
-
-    assert<PredFunc, works>(t);
-    assert<PredFunc, expected>(t);
-});


### PR DESCRIPTION
`Predicate<T>` has a special case so that `Predicate<any>` can accept any number of arguments.  

In general, I think this is an odd exception to the normal behavior, and I actually hit a compiler error while trying to replace our built-in `Predicate<T>` with the one provided here:

```ts
const isNotNil = (x: any) => x != null;

// simplified from `computedPromise`
const test = <T>(t: T, p: Predicate<T> = isNotNil) => p(t);
```

Which errors with the exceptionally ugly message of:

```no-highlight
Type '(x: any) => boolean' is not assignable to type 'If<If<Not<IsArray<T>>, If<If<Not<IsBoolean<T>>, If<If<Not<IsNumber<T>>, If<If<Not<IsString<T>>, If<If<Not<If<T extends AnyFunc<any> ? "1" : "0", "1", If<T extends Function ? "1" : "0", "1", "0">>>, If<...>, "0">, "1", "0">, "0">, "1", "0">, "0">, "1", "0">, "0">, "1", "0">, "0">, (...args: any[]) => boolean, (arg: T...'.
```