### PR TITLE
Simplify is any

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @andnp
-* @Retsam
+* @andnp @Retsam

--- a/src/types/predicates.ts
+++ b/src/types/predicates.ts
@@ -37,13 +37,4 @@ export type IsObject<T> = And<
     Not<IsArray<T>>>
 >;
 
-// hmm...
-export type IsAny<T> =
-    And<Not<IsArray<T>>,
-    And<Not<IsBoolean<T>>,
-    And<Not<IsNumber<T>>,
-    And<Not<IsString<T>>,
-    And<Not<IsFunction<T>>,
-    And<Not<IsNil<T>>,
-    Not<IsObject<T>>>>>>>
->;
+export type IsAny<T> = 0 extends (1 & T) ? True : False;


### PR DESCRIPTION
Thanks to @krisdages for pointing out this simplification! This PR makes
the `IsAny` type much more simple. Previously we were exhaustively
checking that the given type, `T`, was _not_ any other type. This is
pretty prone to mistake and is not very sustainable (a new fundamental
type could be introduced).

Closes #105