### PR TITLE
fix: emit nominal tag in declaration

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -30,7 +30,7 @@ export type Nullable<T> = T | null | undefined;
 /**
  * no-doc - This is a helper for `Nominal` and is not useful on its own
  */
-export declare class Tagged<N extends string> { private _nominal_: N; }
+export declare class Tagged<N extends string> { protected _nominal_: N; }
 /**
  * Constructs a nominal type of type `T`.
  * Useful to prevent any value of type `T` from being used or modified in places it shouldn't (think `id`s).


### PR DESCRIPTION
The `Nominal` type has not been working (possibly for a long time)
because the tag was not being emitted by the typescript compiler. This
didn't show up in testing because the tests are not run against the
emitted definitions.

Instead of emitting:
```typescript
class Tagged<N extends string> { private __tagged__: N }
```
we were getting
```typescript
class Tagged<N extends string> { __tagged__ }
```
thus nothing was tagged any longer.

Switching from `private` to `protected` fixes the emit issue while still
hiding the tag from the end user.