### PR TITLE
Fix intersections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save-dev simplytyped
 
 **[Objects](#objects)**
 
-[AllKeys](#allkeys) - [AllRequired](#allrequired) - [CombineObjects](#combineobjects) - [DeepPartial](#deeppartial) - [DeepReadonly](#deepreadonly) - [DiffKeys](#diffkeys) - [GetKey](#getkey) - [HasKey](#haskey) - [Intersect](#intersect) - [KeysByType](#keysbytype) - [Merge](#merge) - [ObjectKeys](#objectkeys) - [ObjectType](#objecttype) - [Omit](#omit) - [Optional](#optional) - [Overwrite](#overwrite) - [PlainObject](#plainobject) - [PureKeys](#purekeys) - [Required](#required) - [SharedKeys](#sharedkeys) - [StrictUnion](#strictunion) - [StringKeys](#stringkeys) - [TaggedObject](#taggedobject) - [UnionizeProperties](#unionizeproperties) - [UnionKeys](#unionkeys)
+[AllKeys](#allkeys) - [AllRequired](#allrequired) - [CombineObjects](#combineobjects) - [DeepPartial](#deeppartial) - [DeepReadonly](#deepreadonly) - [DiffKeys](#diffkeys) - [ElementwiseIntersect](#elementwiseintersect) - [GetKey](#getkey) - [HasKey](#haskey) - [Intersect](#intersect) - [KeysByType](#keysbytype) - [Merge](#merge) - [ObjectKeys](#objectkeys) - [ObjectType](#objecttype) - [Omit](#omit) - [Optional](#optional) - [Overwrite](#overwrite) - [PlainObject](#plainobject) - [PureKeys](#purekeys) - [Required](#required) - [SharedKeys](#sharedkeys) - [StrictUnion](#strictunion) - [StringKeys](#stringkeys) - [TaggedObject](#taggedobject) - [TryKey](#trykey) - [UnionizeProperties](#unionizeproperties) - [UnionKeys](#unionkeys)
 
 **[Utils](#utils)**
 
@@ -88,12 +88,12 @@ Useful for making extremely complex types look nice in VSCode.
 ```ts
 test('Can combine two objects (without pesky & in vscode)', t => {
     type a = { x: number, y: 'hi' };
-    type b = { z: number, y: 'there' };
+    type b = { z: number };
 
     type got = CombineObjects<a, b>;
     type expected = {
         x: number,
-        y: 'hi' & 'there',
+        y: 'hi',
         z: number
     };
 
@@ -228,6 +228,51 @@ test('Can get all keys that are different between objects', t => {
 
     assert<gotA, 'x'>(t);
     assert<gotB, 'z'>(t);
+});
+```
+
+### ElementwiseIntersect
+Takes two objects and returns their element-wise intersection.
+*Note*: this removes any key-level information, such as optional or readonly keys.
+```ts
+test('Can combine two objects elementwise', t => {
+    type a = { x: number, y: 'hi' };
+    type b = { z: number, y: 'there' };
+
+    type got = ElementwiseIntersect<a, b>;
+    type expected = {
+        x: number,
+        y: 'hi' & 'there',
+        z: number,
+    };
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
+});
+
+test('Can combine two objects with private members elementwise', t => {
+    class A {
+        a: number = 1;
+        private x: number = 2;
+        y: 'hi' = 'hi';
+        private z: 'hey' = 'hey';
+    }
+
+    class B {
+        a: 22 = 22;
+        private x: number = 2;
+        y: 'there' = 'there';
+        private z: 'friend' = 'friend';
+    }
+
+    type got = ElementwiseIntersect<A, B>;
+    type expected = {
+        a: 22,
+        y: 'hi' & 'there',
+    };
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
 });
 ```
 
@@ -469,6 +514,10 @@ exclude any `number | symbol` keys from `keyof`.
 ### TaggedObject
 For discriminated unions of objects, it is important to have a single "tag" property.
 Creates an object with each entry being tagged by the key defining that entry.
+
+
+### TryKey
+Like `GetKey`, but returns `unknown` if the key is not present on the object.
 
 
 ### UnionizeProperties

--- a/scripts/testTsVersions.sh
+++ b/scripts/testTsVersions.sh
@@ -1,6 +1,7 @@
 set -e
 
-for v in 3.0.3 3.1.6 3.2.2 next; do
+# highest patch version of each minor version
+for v in 3.0.3 3.1.6 3.2.4 3.3.4000 3.4.5 3.5.3 3.6.5 3.7.5 3.8.3 next; do
     npm install --no-save typescript@$v
     npm test
 done

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -34,6 +34,23 @@ export type CombineObjects<T extends object, U extends object> = ObjectType<T & 
  * @returns `T[K]` if the key exists, `never` otherwise
  */
 export type GetKey<T, K extends keyof any> = K extends keyof T ? T[K] : never;
+/**
+ * Like `GetKey`, but returns `unknown` if the key is not present on the object.
+ * @param T Object to get values from
+ * @param K Key to query object for value
+ * @returns `T[K]` if the key exists, `unknown` otherwise
+ */
+export type TryKey<T, K extends keyof any> = K extends keyof T ? T[K]: unknown;
+/**
+ * Takes two objects and returns their element-wise intersection.
+ * *Note*: this removes any key-level information, such as optional or readonly keys.
+ * @param T First object to be intersected
+ * @param U Second object to be intersected
+ * @returns element-wise `T` & `U` cleaned up to look like flat object to VSCode
+ */
+export type ElementwiseIntersect<T extends object, U extends object> = {
+    [k in (keyof T | keyof U)]: TryKey<T, k> & TryKey<U, k>;
+};
 
 // ----
 // Keys

--- a/test/objects/CombineObjects.test.ts
+++ b/test/objects/CombineObjects.test.ts
@@ -5,12 +5,12 @@ import { CombineObjects } from '../../src';
 
 test('Can combine two objects (without pesky & in vscode)', t => {
     type a = { x: number, y: 'hi' };
-    type b = { z: number, y: 'there' };
+    type b = { z: number };
 
     type got = CombineObjects<a, b>;
     type expected = {
         x: number,
-        y: 'hi' & 'there',
+        y: 'hi',
         z: number
     };
 

--- a/test/objects/ElementwiseIntersect.test.ts
+++ b/test/objects/ElementwiseIntersect.test.ts
@@ -1,0 +1,44 @@
+import test from 'ava';
+import { assert } from '../helpers/assert';
+
+import { ElementwiseIntersect } from '../../src';
+
+test('Can combine two objects elementwise', t => {
+    type a = { x: number, y: 'hi' };
+    type b = { z: number, y: 'there' };
+
+    type got = ElementwiseIntersect<a, b>;
+    type expected = {
+        x: number,
+        y: 'hi' & 'there',
+        z: number,
+    };
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
+});
+
+test('Can combine two objects with private members elementwise', t => {
+    class A {
+        a: number = 1;
+        private x: number = 2;
+        y: 'hi' = 'hi';
+        private z: 'hey' = 'hey';
+    }
+
+    class B {
+        a: 22 = 22;
+        private x: number = 2;
+        y: 'there' = 'there';
+        private z: 'friend' = 'friend';
+    }
+
+    type got = ElementwiseIntersect<A, B>;
+    type expected = {
+        a: 22,
+        y: 'hi' & 'there',
+    };
+
+    assert<got, expected>(t);
+    assert<expected, got>(t);
+});


### PR DESCRIPTION
In typescript 3.9.0, the intersection between two objects will be
`never` if the two objects have incompatible private members. This broke
an implicit behavior that `CombineObjects` was taking advantage of;
element-wise intersection. Because `CombineObjects` is intended to be a
thin wrapper over the raw intersection type, I don't want its contract
to deviate from the intersection. So instead I added the
`ElementwiseIntersect` utility; which relies on the newly added `TryKey`
utility.

`TryKey` is just like `GetKey`, except it fails "silently" when the key
does not exist. Specifically, `GetKey` returns `never` so that the
resultant type is unusable and `TryKey` returns `unknown` which can be
eliminated via intersection.

Relevant PR from typescript which changed behavior of intersections (and
broke the future-proofing test cases):
microsoft/TypeScript#37762