### PR TITLE
chore: add deno compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 package-lock.json
 node_modules
 dist/
+edition*/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The goal is to provide all of the building blocks necessary to make concise, yet
 npm install --save-dev simplytyped
 ```
 
+To use with [Deno](https://deno.land), import `https://unpkg.com/simplytyped@^1.1.0/edition-deno/index.ts`
+
 ## Table of Contents
 
 **[Objects](#objects)**

--- a/package.json
+++ b/package.json
@@ -1,10 +1,38 @@
 {
     "name": "simplytyped",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "description": "yet another Typescript type library for advanced types",
     "main": "dist/src/index",
     "types": "dist/src/index.d.ts",
+    "deno": "edition-deno/index.ts",
+    "browser": "edition-deno/index.ts",
     "private": true,
+    "editions": [
+        {
+            "description": "TypeScript source code with Import for modules",
+            "directory": "src",
+            "entry": "index.ts",
+            "tags": [
+                "typescript",
+                "import"
+            ],
+            "engines": false
+        },
+        {
+            "description": "TypeScript source code made to be compatible with Deno",
+            "directory": "edition-deno",
+            "entry": "index.ts",
+            "tags": [
+                "typescript",
+                "import",
+                "deno"
+            ],
+            "engines": {
+                "deno": true,
+                "browsers": true
+            }
+        }
+    ],
     "scripts": {
         "doc": "ts-node scripts/generateDocumentation.ts > README.md",
         "commitDocs": "sh scripts/commitDocsIfChanged.sh",
@@ -12,7 +40,7 @@
         "test": "npm run -s tsc && NODE_PATH=src/ ava",
         "test:all": "sh scripts/testTsVersions.sh",
         "tsc": "tsc",
-        "prepub": "rm -rf dist && npm -s run tsc && ts-node scripts/preparePublish.ts",
+        "prepub": "rm -rf dist && npm -s run tsc && ts-node scripts/preparePublish.ts && make-deno-edition",
         "release": "npm run -s prepub && cd dist/src && npx semantic-release"
     },
     "repository": {
@@ -29,7 +57,8 @@
         "url": "https://github.com/andnp/SimplyTyped/issues"
     },
     "files": [
-        "dist/src"
+        "dist/src",
+        "edition-deno"
     ],
     "homepage": "https://github.com/andnp/SimplyTyped#readme",
     "peerDependencies": {
@@ -42,6 +71,7 @@
         "ava": "~3.7.1",
         "commitlint": "^8.0.0",
         "husky": "^4.0.2",
+        "make-deno-edition": "^0.2.1",
         "ts-node": "^8.0.3",
         "tslint": "^5.13.0"
     },


### PR DESCRIPTION
Adds compatibility for [Deno](https://deno.land) using [`make-deno-edition`](https://github.com/bevry/make-deno-edition)

Note that when it runs, it will change the `package.json` indentation to 2 spaces, which is the standard for JSON files.

The version number in the `README.md` may also need to be adjusted.

To get it working locally, I also had to `npm i --save-dev typescript` so that the `npm run prepub` detected `tsc`.

If you wish to also add the [edition](https://editions.bevry.me) metadata for the compiled javascript edition, it would be like so:

``` json
         {
             "description":  "TypeScript compiled against ES5 for Node.js with Require for modules",
             "directory": "dist/src",
             "entry": "index.js",
             "tags": [
                 "javascript",
                 "es5",
                 "require"
             ],
             "engines": {
                 "node": true,
                 "browsers": false,
                 "deno": false
             }
         }
```